### PR TITLE
Add Rake integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A [Guard][] plugin for checking and optionally fixing [Terraform](https://www.te
 
 By running Guard, the formatting is automatically checked every time a `.tf` or `.tfvars` file is added or modified. By default all issues are printed as diff, but automatic rewrite is also possible, and maybe even recommended.
 
+This project also includes a [Rake](https://ruby.github.io/rake/) task.
+
 ## Installation
 
 This plugin requires Terraform to be installed on the system. This can be done e.g. [the official way](https://learn.hashicorp.com/terraform/getting-started/install.html), or with [chtf](https://github.com/Yleisradio/homebrew-terraforms#readme) on Mac. Guard::Terraform should be compatible with all (well, at least reasonably recent) Terraform versions.
@@ -77,7 +79,7 @@ end
 
 Available options and their default values:
 
-``` ruby
+```ruby
 all_on_start: true  # Check all files on start?
 
 diff:  true         # Show diffs of the changes?
@@ -89,6 +91,39 @@ Notes:
 * `diff` should be enabled at least if `write` is disabled, or it might be difficult to catch the issues.
 * When `write` is enabled and if Terraform rewrites a file, Guard will catch the modification and pass the file again to Guard::Terraform. So the file is checked again, but should of course pass this time.
 
+## Rake Integration
+
+To run Terraform format checks easily with [Rake](https://ruby.github.io/rake/), add the `rake` gem to the `Gemfile`, and this to a `Rakefile`:
+
+```ruby
+require 'terraform/rake_task'
+
+Terraform::RakeTask.new
+```
+
+Then you can run the task with:
+
+```sh
+$ bundle exec rake terraform
+```
+
+Another example that creates two tasks: one for checking and another for auto-correcting the formatting. Tasks can be listed with `bundle exec rake -T`.
+
+```ruby
+require 'terraform/rake_task'
+
+task default: 'terraform:check'
+
+namespace :terraform do
+  desc 'Check Terraform file formatting'
+  Terraform::RakeTask.new(:check)
+
+  desc 'Auto-correct Terraform file formatting'
+  Terraform::RakeTask.new(:fix) do |task|
+    task.write = true
+  end
+end
+```
 
 ## Contributing
 

--- a/lib/terraform/rake_task.rb
+++ b/lib/terraform/rake_task.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'rake'
+require 'rake/tasklib'
+
+require 'terraform'
+
+class Terraform
+  # Provides a method to define a Rake task that
+  # checks and optionally fixes Terraform configuration format
+  class RakeTask < Rake::TaskLib
+    # Name of task (default: `:terraform`)
+    attr_accessor :name
+
+    # Path to the project root (default: `.`)
+    attr_accessor :project_root
+
+    # Show diffs of the changes? (default: `true`)
+    attr_accessor :diff
+
+    # Fix the formatting instead of just verifying? (default: `false`)
+    attr_accessor :write
+
+    # Whether or not to fail Rake when an error occurs.
+    # If `write` is disabled, this include formatting issues.
+    attr_accessor :fail_on_error
+
+    # Use verbose output. If this is set to true, the task will print the
+    # executed commands. Defaults to `true`.
+    attr_accessor :verbose
+
+    def initialize(*args, &task_block)
+      @name = args.shift || :terraform
+
+      @project_root = '.'
+
+      @diff  = true
+      @write = false
+
+      @fail_on_error = true
+      @verbose       = true
+
+      define(args, &task_block)
+    end
+
+    def terraform
+      @terraform ||= Terraform.new
+    end
+
+    def define(args, &task_block)
+      desc('Check Terraform file formatting') if !Rake.application.last_description
+
+      task(name, *args) do |_, task_args|
+        RakeFileUtils.verbose(verbose) do
+          yield(*[self, task_args].slice(0, task_block.arity)) if block_given?
+          run_task
+        end
+      end
+    end
+
+    def run_task
+      rake_output_message("#{write ? 'Auto-correcting' : 'Inspecting'}" \
+                          " Terraform formatting for #{project_root}")
+
+      result = terraform.fmt(paths, tf_flags, &print_commands_proc)
+
+      abort('Terraform file formatting check failed') if !result && fail_on_error
+    end
+
+    def paths
+      paths = [project_root]
+      paths += terraform.find_tfvars_files if terraform.pre_0_12?
+      paths
+    end
+
+    def tf_flags
+      {}.tap do |flags|
+        flags[:diff]  = !!diff  # rubocop:disable Style/DoubleNegation
+        flags[:write] = !!write # rubocop:disable Style/DoubleNegation
+        flags[:check] = !write
+        flags[:recursive] = true if !terraform.pre_0_12?
+      end
+    end
+
+    def print_commands_proc
+      return if !verbose
+
+      proc { |_, cmd| rake_output_message(cmd.join(' ')) }
+    end
+  end
+end

--- a/spec/lib/terraform/rake_task_spec.rb
+++ b/spec/lib/terraform/rake_task_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'support/terraform_versions'
+
+require 'terraform/rake_task'
+
+RSpec.describe Terraform::RakeTask do
+  subject(:task) { described_class.new }
+
+  let(:terraform) { instance_double(::Terraform) }
+  let(:fmt_result) { true }
+  let(:tfvars_files) { %w[foo.tfvars bar/baz.tfvars] }
+
+  before do
+    Rake::Task.clear
+
+    allow(::Terraform).to receive(:new) { terraform }
+    allow(terraform).to receive(:find_tfvars_files) { tfvars_files }
+  end
+
+  after do
+    Rake::Task.clear
+  end
+
+  describe 'defining tasks' do
+    context 'with default name' do
+      it 'creates a task' do
+        described_class.new
+
+        expect(Rake::Task.task_defined?(:terraform)).to be true
+      end
+    end
+
+    context 'with specified name' do
+      it 'creates a task' do
+        described_class.new(:something)
+
+        expect(Rake::Task.task_defined?(:something)).to be true
+      end
+    end
+  end
+
+  describe 'running the task' do
+    before do
+      $stdout = StringIO.new
+      $stderr = StringIO.new
+    end
+
+    after do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+
+    context 'with pre-0.12 Terraform version', :terraform_pre_012 do
+      context 'with defaults' do
+        before do
+          described_class.new
+        end
+
+        it 'calls Terraform with root dir and tfvars files' do
+          paths = ['.'] + tfvars_files
+          expect(terraform).to receive(:fmt).with(paths, anything) { true }
+
+          Rake::Task[:terraform].execute
+        end
+
+        it 'calls Terraform with default flags' do
+          flags = { check: true, diff: true, write: false }
+          expect(terraform).to receive(:fmt).with(anything, flags) { true }
+
+          Rake::Task[:terraform].execute
+        end
+
+        context 'on failure' do
+          before do
+            allow(terraform).to receive(:fmt) { false }
+          end
+
+          it 'exits with error code' do
+            expect { Rake::Task[:terraform].execute }.to raise_error(SystemExit)
+            expect($stderr.string).to match(/Terraform .* failed/)
+          end
+        end
+      end
+
+      context 'with specified options' do
+        context 'with write enabled' do
+          it 'also disables check' do
+            described_class.new do |task|
+              task.project_root = '/somewhere/else'
+              task.write = true
+            end
+
+            expect(terraform).to receive(:fmt).with(
+              array_including('/somewhere/else'),
+              hash_including(write: true, check: false)
+            ) { true }
+
+            Rake::Task[:terraform].execute
+          end
+        end
+
+        context 'with fail_on_error disabled' do
+          context 'on failure' do
+            before do
+              described_class.new do |task|
+                task.fail_on_error = false
+              end
+
+              allow(terraform).to receive(:fmt) { false }
+            end
+
+            it 'does not exit with error code on error' do
+              expect { Rake::Task[:terraform].execute }.not_to raise_error
+            end
+
+            it 'does not print out error message' do
+              expect { Rake::Task[:terraform].execute }.not_to output(/failed/).to_stderr
+            end
+          end
+        end
+      end
+    end
+
+    context 'with 0.12+ Terraform version', :terraform_post_012 do
+      context 'with defaults' do
+        before do
+          described_class.new
+        end
+
+        it 'calls Terraform with only root dir' do
+          expect(terraform).to receive(:fmt).with(['.'], anything) { true }
+
+          Rake::Task[:terraform].execute
+        end
+
+        it 'calls Terraform with default flags' do
+          flags = { check: true, diff: true, write: false, recursive: true }
+          expect(terraform).to receive(:fmt).with(anything, flags) { true }
+
+          Rake::Task[:terraform].execute
+        end
+
+        context 'on failure' do
+          before do
+            allow(terraform).to receive(:fmt) { false }
+          end
+
+          it 'exits with error code' do
+            expect { Rake::Task[:terraform].execute }.to raise_error(SystemExit)
+            expect($stderr.string).to match(/Terraform .* failed/)
+          end
+        end
+      end
+
+      context 'with specified options' do
+        context 'with write enabled' do
+          it 'also disables check' do
+            described_class.new do |task|
+              task.project_root = '/somewhere/else'
+              task.write = true
+            end
+
+            expect(terraform).to receive(:fmt).with(
+              array_including('/somewhere/else'),
+              hash_including(write: true, check: false)
+            ) { true }
+
+            Rake::Task[:terraform].execute
+          end
+        end
+
+        context 'with fail_on_error disabled' do
+          context 'on failure' do
+            before do
+              described_class.new do |task|
+                task.fail_on_error = false
+              end
+
+              allow(terraform).to receive(:fmt) { false }
+            end
+
+            it 'does not exit with error code on error' do
+              expect { Rake::Task[:terraform].execute }.not_to raise_error
+            end
+
+            it 'does not print out error message' do
+              expect { Rake::Task[:terraform].execute }.not_to output(/failed/).to_stderr
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `Terraform::RakeTask` helper to run Terraform format checks easily with [Rake](https://ruby.github.io/rake/).

A `Rakefile` example:
```ruby
require 'terraform/rake_task'

task default: 'terraform:check'

namespace :terraform do
  desc 'Check Terraform file formatting'
  Terraform::RakeTask.new(:check)

  desc 'Auto-correct Terraform file formatting'
  Terraform::RakeTask.new(:fix) do |task|
    task.write = true
  end
end
```